### PR TITLE
Check for  Content Type header in deserialize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ function fetchMiddleware ({dispatch, getState}) {
  */
 
 function deserialize (res) {
-  return res.headers.get('Content-Type').indexOf('application/json') > -1
+  var header = res.headers.get('Content-Type');
+  return (header && header.indexOf('application/json') > -1)
     ? res.json()
     : res.text()
 }


### PR DESCRIPTION
This was blowing up for me on DELETEs, which return a `204 No Content` empty response. I added a simple check and it's all good.