### PR TITLE
Add automatic json encoding

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  presets: ["es2015"]
+  presets: ["es2015", "stage-1"]
 }

--- a/Readme.md
+++ b/Readme.md
@@ -12,9 +12,10 @@ This package is designed to be used in conjunction with [redux-effects](https://
 
 ```javascript
 import effects from 'redux-effects'
-import fetch from 'redux-effects-fetch'
+import fetch, { fetchEncodeJSON } from 'redux-effects-fetch'
 
-applyMiddleware(effects, fetch)(createStore)
+// fetchEncodeJSON is optional
+applyMiddleware(effects, fetch, fetchEncodeJSON)(createStore)
 ```
 
 This will enable your middleware to support fetch actions.
@@ -92,4 +93,3 @@ const setError = createAction('SET_ERROR')
 If you want to develope your frontend application without any REST server running,
 you can use [redux-effects-fetch-fixture](https://github.com/team-boris/redux-effects-fetch-fixture) to define
 fixtures for your `fetch` requests.
-

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Declarative data-fetching for redux",
   "main": "lib/index.js",
   "scripts": {
+    "test": "babel-tape-runner test/*.js | tap-spec",
     "prepublish": "rm -rf lib && babel src --out-dir lib",
     "postpublish": "rm -rf lib"
   },
@@ -26,8 +27,12 @@
     "isomorphic-fetch": "^2.1.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.6.5",
     "babel-preset-es2015": "^6.3.13",
+    "babel-preset-stage-1": "^6.5.0",
     "babel-tape-runner": "^2.0.0",
+    "lodash": "^4.8.1",
+    "tap-spec": "^4.1.1",
     "tape": "^4.2.0"
   }
 }

--- a/src/fetchEncodeJSON.js
+++ b/src/fetchEncodeJSON.js
@@ -1,0 +1,57 @@
+import {FETCH} from './index';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/4.8.0/lodash.js#L10705
+ * @see https://lodash.com/docs#isObject
+ */
+function isObject(value) {
+  const type = typeof value;
+  return !!value && (type == 'object' || type == 'function');
+}
+
+/**
+ * A middleware which automatically converts object bodies to JSON for fetch effects.
+ *
+ * The middleware intercepts all fetch actions, and encodes their body to JSON if
+ *
+ * - the request has a `Content-Type: application/json` and
+ * - the body is an object.
+ *
+ * In this case it also adds an `Accept: application/json` header but only if there's no other `Accept` header yet.
+ *
+ * Hook into **before** the regular fetch middleware.
+ */
+const fetchEncodeJSON = () => next => action =>
+  action.type === FETCH ?
+    next(maybeConvertBodyToJSON(action)) :
+    next(action);
+
+/**
+ * Whether we may convert a request with the given params to JSON.
+ */
+const shallConvertToJSON = (params) =>
+      isObject(params.body) && params.headers && params.headers['Content-Type'] === 'application/json';
+
+/**
+ * Add an accept header if necessary.
+ *
+ * Add an `Accept: application/json` header to the given headers but only if they don't already contain an `Accept`
+ * header.
+ */
+const maybeAddAcceptHeader = (headers) =>
+      headers.hasOwnProperty('Accept') ? headers : {...headers, 'Accept': 'application/json'};
+
+const maybeConvertBodyToJSON = action => {
+  const { payload } = action;
+  if (shallConvertToJSON(payload.params)) {
+    const body = JSON.stringify(payload.params.body);
+    const headers = maybeAddAcceptHeader(payload.params.headers);
+    const params = {...payload.params, body, headers};
+    const result = {...action, payload: {...payload, params: params}};
+    return result;
+  } else {
+    return action;
+  }
+};
+
+export default fetchEncodeJSON;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
  */
 
 import realFetch from 'isomorphic-fetch'
+import fetchEncodeJSON from './fetchEncodeJSON'
 
 /**
  * Action types
@@ -93,5 +94,6 @@ function fetch (url = '', params = {}) {
 export default fetchMiddleware
 export {
   fetch,
-  FETCH
+  FETCH,
+  fetchEncodeJSON
 }

--- a/test/fetchEncodeJSONSpec.js
+++ b/test/fetchEncodeJSONSpec.js
@@ -1,0 +1,106 @@
+import test from 'tape'
+import {omit} from 'lodash/object'
+import {fetch, fetchEncodeJSON} from '../src'
+
+
+const run = (action, cb) => fetchEncodeJSON()(cb)(action)
+
+
+test('should ignore other actions', t => {
+  const action = {
+    type: 'NO_FETCH',
+    payload: {}
+  }
+
+  run(action, newAction => {
+    t.equal(newAction, action);
+    t.end();
+  })
+})
+
+test('non-JSON requests', t => {
+    const action = fetch('/foo', {method: 'POST', headers: {'Content-Type': 'text/plain'}, body: 'foo'});
+    run(action, newAction => {
+      t.equal(newAction, action)
+      t.end()
+    })
+})
+
+
+test('should ignore requests whose body is a string', t => {
+  const action = fetch('/foo', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: 'foo'
+  })
+  run(action, newAction => {
+    t.equal(newAction, action)
+    t.end()
+  })
+})
+
+test('should encode the body if it is an object', t => {
+  const request = {
+    method: 'POST',
+    body: {message: 'Hello world!'},
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
+  }
+  const action = fetch('/foo', request)
+  const payload = action.payload
+
+  run(action, newAction => {
+    t.equal(newAction.payload.params.body,JSON.stringify({message: 'Hello world!'}));
+    // Ensure that the payload is otherwise unmodified
+    t.same(omit(newAction.payload.params, ['body']), omit(payload.params, ['body']));
+    t.same(omit(newAction.payload, ['params']), omit(payload, ['params']));
+    t.end()
+  });
+})
+
+test('should add an accept header if it encoded the object', t => {
+  const request = {
+    method: 'POST',
+    body: {message: 'Hello world!'},
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Foo': 'bar'
+    }
+  }
+  const action = fetch('/foo', request)
+  const payload = action.payload
+  run(action, newAction => {
+    t.same(newAction.payload.params.headers, {
+      'X-Foo': 'bar',
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    })
+    // Ensure that the payload is otherwise unmodified
+    t.same(omit(newAction.payload.params, ['body', 'headers']), omit(payload.params, ['body', 'headers']))
+    t.same(omit(newAction.payload, ['params']), omit(payload, ['params']))
+    t.end()
+  })
+})
+
+test('should leave an existing accept header untouched', t => {
+  const request = {
+    method: 'POST',
+    body: {message: 'foo'},
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'text/plain'
+    }
+  }
+  const action = fetch('/foo', request)
+
+  run(action, newAction => {
+    t.same(newAction.payload.params.body,JSON.stringify({message: 'foo'}))
+    t.same(newAction.payload.params.headers, {
+      'Content-Type': 'application/json',
+      'Accept': 'text/plain'
+    })
+    t.end()
+  })
+})


### PR DESCRIPTION
This feature lets you add automatic json encoding to your fetch pipeline.


```javascript
import effects from 'redux-effects'
import fetch, { fetchEncodeJSON } from 'redux-effects-fetch'

// fetchEncodeJSON is optional
applyMiddleware(effects, fetch, fetchEncodeJSON)(createStore)
```

- `Accept` header will be set
- `JSON.stringify(body)` is automatically applied