### PR TITLE
Make redux-effects-fetch mockable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
  * Imports
  */
 
-import realFetch from 'isomorphic-fetch'
+import 'isomorphic-fetch'
 import fetchEncodeJSON from './fetchEncodeJSON'
 
 /**
@@ -18,7 +18,7 @@ const FETCH = 'EFFECT_FETCH'
 function fetchMiddleware ({dispatch, getState}) {
   return next => action =>
     action.type === FETCH
-      ? realFetch(action.payload.url, action.payload.params).then(checkStatus).then(createResponse, createErrorResponse)
+      ? fetch(action.payload.url, action.payload.params).then(checkStatus).then(createResponse, createErrorResponse)
       : next(action)
 }
 
@@ -77,7 +77,7 @@ function checkStatus (res) {
  * Action creator
  */
 
-function fetch (url = '', params = {}) {
+function fetchActionCreator (url = '', params = {}) {
   return {
     type: FETCH,
     payload: {
@@ -93,7 +93,7 @@ function fetch (url = '', params = {}) {
 
 export default fetchMiddleware
 export {
-  fetch,
+  fetchActionCreator as fetch,
   FETCH,
   fetchEncodeJSON
 }


### PR DESCRIPTION
I found a problem with mocking redux-effects-fetch using [fetch-mock](https://github.com/wheresrhys/fetch-mock) package.

Here’s the test file:

```JS
import configureStore from 'redux-mock-store'
import effects from 'redux-effects'
import fetchMiddleware from 'redux-effects-fetch'
import action from 'src/actions/foobar'

storeMock = configureStore([effects, fetchMiddleware])()
fetchMock.mock('^http://foobar', 'GET')
storeMock.dispatch(action) // It makes real request to http://foobar, not mocked
```

The problem is when you import fetch like that `import realFetch from ‘isomorphic-fetch’`, you isolate it, so then you can’t mock it. 