### PR TITLE
Add support for timeout

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,18 +30,20 @@ You can create your own action creators for this package, or you can use the one
   payload: {
     url,
     params
-  }
+  },
+  meta: { timeout }
 }
 ```
 
-Where `url` and `params` are what you would pass as the first and second arguments to the native `fetch` API.  If you want your action creators to support some async flow control, you should use [redux-effects](https://github.com/redux-effects/redux-effects)' `bind` function.  If you do, your fetch action will return you an object with the following properties:
+Where `url` and `params` are what you would pass as the first and second arguments to the native `fetch` API. Third argument is action meta: `timeout` - the numerical value (in ms) which is used for rejecting request promise if it takes longer time to complete than the value of this property.
+
+If you want your action creators to support some async flow control, you should use [redux-effects](https://github.com/redux-effects/redux-effects)' `bind` function.  If you do, your fetch action will return you an object with the following properties:
 
   * `url` - The url of the endpoint you requested (as returned by the request)
   * `status` - The numerical status code of the response (e.g. 200)
   * `statusText` - The text version of the status (e.g. 'OK')
   * `headers` - A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
   * `value` - The deserialized value of the response.  This may be an object or string, depending on the type of response (json or text).
-  * `timeout` - The numerical value (in ms) which is used for rejecting request promise if it takes longer time to complete than the value of this property
 
 ## Examples
 
@@ -80,7 +82,7 @@ function signupUser (user) {
     bind(fetch(api + '/user', {
       method: 'POST',
       body: user
-    }), ({value}) => userDidLogin(value), ({value}) => setError(value))
+    }, { timeout: 10000 }), ({value}) => userDidLogin(value), ({value}) => setError(value))
   ]
 }
 

--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,7 @@ Where `url` and `params` are what you would pass as the first and second argumen
   * `statusText` - The text version of the status (e.g. 'OK')
   * `headers` - A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
   * `value` - The deserialized value of the response.  This may be an object or string, depending on the type of response (json or text).
+  * `timeout` - The numerical value (in ms) which is used for rejecting request promise if it takes longer time to complete than the value of this property
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-1": "^6.5.0",
     "babel-tape-runner": "^2.0.0",
+    "fetch-mock": "5.9.4",
     "lodash": "^4.8.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.0"

--- a/src/index.js
+++ b/src/index.js
@@ -18,19 +18,19 @@ const FETCH = 'EFFECT_FETCH'
 function fetchMiddleware ({dispatch, getState}) {
  return next => action =>
     action.type === FETCH
-      ? getRequestPromise(action.payload)
+      ? getRequestPromise(action.payload, action.meta)
           .then(checkStatus)
           .then(createResponse, createErrorResponse)
       : next(action)
 }
 
-function getRequestPromise ({ params, url }) {
+function getRequestPromise ({ params, url }, meta) {
   const fetchPromise = g().fetch(url, params)
 
-  if (params && typeof params.timeout === 'number') {
+  if (meta && typeof meta.timeout === 'number') {
     const rejectOnTimeout = new Promise((_, reject) => {
       const error = new Error(`Request to ${url} timed out`)
-      setTimeout(() => reject(error), params.timeout)
+      setTimeout(() => reject(error), meta.timeout)
     })
 
     return Promise.race([fetchPromise, rejectOnTimeout])
@@ -110,13 +110,14 @@ function checkStatus (res) {
  * Action creator
  */
 
-function fetchActionCreator (url = '', params = {}) {
+function fetchActionCreator (url = '', params = {}, meta = {}) {
   return {
     type: FETCH,
     payload: {
       url,
       params
-    }
+    },
+    meta
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -47,7 +47,7 @@ test('should work', t => {
 
 test('should reject on timeout', t => {
   t.plan(1)
-  run(fetch(urlTimeout, { timeout: 1000 })).then(() => t.fail(), (res) => t.pass())
+  run(fetch(urlTimeout, {}, { timeout: 1000 })).then(() => t.fail(), (res) => t.pass())
 })
 
 test('should reject on invalid response', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -6,15 +6,15 @@ import test from 'tape'
 import fetchMock from 'fetch-mock'
 import fetchMw, {fetch} from '../src'
 
-const urlTimeout = 'http://localhost/timeout'
+const timeoutUrl = 'http://localhost/timeout'
 
-const urlSuccess = 'http://localhost/200'
+const successUrl = 'http://localhost/200'
 
 const failureUrl = 'http://localhost/404'
 
-fetchMock.get(urlTimeout, new Promise(res => setTimeout(res, 2000)).then(() => 200));
+fetchMock.get(timeoutUrl, new Promise(res => setTimeout(res, 2000)).then(() => 200));
 
-fetchMock.get(urlSuccess, {
+fetchMock.get(successUrl, {
   headers: { 'Content-Type': ['text/html'] },
 });
 
@@ -36,8 +36,8 @@ const run = fetchMw(api)(() => {})
  */
 
 test('should work', t => {
-  run(fetch(urlSuccess)).then(({url, headers, value, status, statusText}) => {
-    t.equal(url, urlSuccess)
+  run(fetch(successUrl)).then(({url, headers, value, status, statusText}) => {
+    t.equal(url, successUrl)
     t.equal(status, 200)
     t.equal(statusText, 'OK')
     t.ok(headers.get('content-type').indexOf('text/html') !== -1)
@@ -47,7 +47,7 @@ test('should work', t => {
 
 test('should reject on timeout', t => {
   t.plan(1)
-  run(fetch(urlTimeout, {}, { timeout: 1000 })).then(() => t.fail(), (res) => t.pass())
+  run(fetch(timeoutUrl, {}, { timeout: 1000 })).then(() => t.fail(), (res) => t.pass())
 })
 
 test('should reject on invalid response', t => {


### PR DESCRIPTION
Sometimes there is a need to reject request promise, if the request is taking too long to complete.

Changes:

* Reject request promise if it takes longer time to complete than the specified amount which is defined as params.timeout

* Update tests - use fetch-mock library, add test for newly added timeout functionality